### PR TITLE
Module unification updates

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,8 @@ function getDefaultConfig() {
     coverageEnvVar: 'COVERAGE',
     coverageFolder: 'coverage',
     excludes: [
-      '*/mirage/**/*'
+      '*/mirage/**/*',
+      '**/*-test*'
     ],
     reporters: [
       'html',


### PR DESCRIPTION
omits -test files from being included in coverage.

I'll close https://github.com/kategengler/ember-cli-code-coverage/pull/201
if this pr #1 is merged :)

![image](https://user-images.githubusercontent.com/199018/46531403-18ec5f00-c86b-11e8-9f3e-522e0fe79ba4.png)
